### PR TITLE
IBM-Swift/Kitura#836 Switch out deprecated server.listen calls

### DIFF
--- a/Tests/CredentialsHTTPTests/CredentialsTest.swift
+++ b/Tests/CredentialsHTTPTests/CredentialsTest.swift
@@ -35,21 +35,24 @@ extension CredentialsTest {
     }
 
     func performServerTest(router: ServerDelegate, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
-        let server = setupServer(port: 8090, delegate: router)
-        sleep(10)
-        let requestQueue = DispatchQueue(label: "Request queue")
+        do {
+            let server = try HTTPServer.listen(on: 8090, delegate: router)
+            let requestQueue = DispatchQueue(label: "Request queue")
 
-        for (index, asyncTask) in asyncTasks.enumerated() {
-            let expectation = self.expectation(index)
-            requestQueue.async {
-                asyncTask(expectation)
+            for (index, asyncTask) in asyncTasks.enumerated() {
+                let expectation = self.expectation(index)
+                requestQueue.async {
+                    asyncTask(expectation)
+                }
             }
-        }
 
-        waitExpectation(timeout: 10) { error in
-            // blocks test until request completes
-            server.stop()
-            XCTAssertNil(error);
+            waitExpectation(timeout: 10) { error in
+                // blocks test until request completes
+                server.stop()
+                XCTAssertNil(error);
+            }
+        } catch {
+            XCTFail("Error: \(error)")
         }
     }
 
@@ -68,10 +71,6 @@ extension CredentialsTest {
             requestModifier(req)
         }
         req.end()
-    }
-
-    private func setupServer(port: Int, delegate: ServerDelegate) -> HTTPServer {
-        return HTTPServer.listen(port: port, delegate: delegate)
     }
 }
 


### PR DESCRIPTION
- Switch out deprecated server.listen calls handling errors as needed
- Remove now redundant sleep calls