### PR TITLE
Fix the build break and update to Kitura 1.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,6 @@ import PackageDescription
 let package = Package(
     name: "Kitura-CredentialsHTTP",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", majorVersion: 1, minor: 2),
+        .Package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", majorVersion: 1, minor: 3),
     ]
 )

--- a/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
@@ -84,8 +84,8 @@ public class CredentialsHTTPBasic : CredentialsPluginProtocol {
                               inProgress: @escaping () -> Void)  {
         
         var authorization : String
-        if let userinfo = request.parsedURL.userinfo {
-            authorization = userinfo
+        if let user = request.urlComponents.user, let password = request.urlComponents.password {
+            authorization = user + ":" + password
         }
         else {
             let options = Data.Base64DecodingOptions(rawValue: 0)

--- a/Sources/CredentialsHTTP/CredentialsHTTPDigest.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPDigest.swift
@@ -90,7 +90,7 @@ public class CredentialsHTTPDigest : CredentialsPluginProtocol {
         guard let credentials = CredentialsHTTPDigest.parse(params: String(authorizationHeader.characters.dropFirst(7))), credentials.count > 0,
             let userid = credentials["username"],
             let credentialsRealm = credentials["realm"], credentialsRealm == realm,
-            let credentialsURI = credentials["uri"], credentialsURI == request.originalURL,
+            let credentialsURI = credentials["uri"], credentialsURI == request.urlComponents.path,
             let credentialsNonce = credentials["nonce"],
             let credentialsCNonce = credentials["cnonce"],
             let credentialsNC = credentials["nc"],

--- a/Tests/CredentialsHTTPTests/CredentialsTest.swift
+++ b/Tests/CredentialsHTTPTests/CredentialsTest.swift
@@ -30,8 +30,11 @@ protocol CredentialsTest {
 
 extension CredentialsTest {
 
+    func doSetUp() {
+        PrintLogger.use()
+    }
+    
     func doTearDown() {
-        //       sleep(10)
     }
 
     func performServerTest(router: ServerDelegate, asyncTasks: @escaping (XCTestExpectation) -> Void...) {

--- a/Tests/CredentialsHTTPTests/PrintLogger.swift
+++ b/Tests/CredentialsHTTPTests/PrintLogger.swift
@@ -1,0 +1,35 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import LoggerAPI
+
+public class PrintLogger: Logger {
+    public func log(_ type: LoggerMessageType, msg: String,
+                    functionName: String, lineNum: Int, fileName: String ) {
+        print("\(type): \(functionName) \(fileName) line \(lineNum) - \(msg)")
+    }
+
+    public func isLogging(_ level: LoggerAPI.LoggerMessageType) -> Bool {
+        return true
+    }
+    
+    public static func use() {
+        Log.logger = PrintLogger()
+        setbuf(stdout, nil)
+    }
+}

--- a/Tests/CredentialsHTTPTests/TestBasic.swift
+++ b/Tests/CredentialsHTTPTests/TestBasic.swift
@@ -33,6 +33,10 @@ class TestBasic : XCTestCase {
         ]
     }
     
+    override func setUp() {
+        doSetUp()
+    }
+    
     override func tearDown() {
         doTearDown()
     }

--- a/Tests/CredentialsHTTPTests/TestDigest.swift
+++ b/Tests/CredentialsHTTPTests/TestDigest.swift
@@ -33,6 +33,10 @@ class TestDigest : XCTestCase {
         ]
     }
     
+    override func setUp() {
+        doSetUp()
+    }
+    
     override func tearDown() {
         doTearDown()
     }


### PR DESCRIPTION
Kitura 1.3 API changes broke Kitura-CredentialsHTTP this PR fixes the breaks.

Tested by running locally the Kitura-CredentialsHTTP unit tests on both macOS and Linux.

This fixes issue IBM-Swift/Kitura#898