### PR TITLE
IBM-Swift/Kitura-CredentialsHTTP#33 Check that the Authorization header contains at least two components before accessing them

### DIFF
--- a/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
@@ -90,14 +90,13 @@ public class CredentialsHTTPBasic : CredentialsPluginProtocol {
         else {
             let options = Data.Base64DecodingOptions(rawValue: 0)
             
-            guard request.headers["Authorization"] != nil,
-                let authorizationHeader = request.headers["Authorization"]  else {
-                    onPass(.unauthorized, ["WWW-Authenticate" : "Basic realm=\"" + self.realm + "\""])
-                    return
+            guard let authorizationHeader = request.headers["Authorization"]  else {
+                onPass(.unauthorized, ["WWW-Authenticate" : "Basic realm=\"" + self.realm + "\""])
+                return
             }
 
             let authorizationHeaderComponents = authorizationHeader.components(separatedBy: " ")
-            guard authorizationHeaderComponents.count >= 2,
+            guard authorizationHeaderComponents.count == 2,
                 authorizationHeaderComponents[0] == "Basic",
                 let decodedData = Data(base64Encoded: authorizationHeaderComponents[1], options: options),
                 let userAuthorization = String(data: decodedData, encoding: .utf8) else {

--- a/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
@@ -91,16 +91,18 @@ public class CredentialsHTTPBasic : CredentialsPluginProtocol {
             let options = Data.Base64DecodingOptions(rawValue: 0)
             
             guard request.headers["Authorization"] != nil,
-                let authorizationHeader = request.headers["Authorization"],
-                        authorizationHeader.components(separatedBy: " ")[0] == "Basic",
-                        let decodedData = Data(base64Encoded: authorizationHeader.components(separatedBy: " ")[1], options: options) else {
+                let authorizationHeader = request.headers["Authorization"]  else {
                     onPass(.unauthorized, ["WWW-Authenticate" : "Basic realm=\"" + self.realm + "\""])
                     return
             }
 
-            guard let userAuthorization = String(data: decodedData, encoding: .utf8) else {
-                onPass(.unauthorized, ["WWW-Authenticate" : "Basic realm=\"" + self.realm + "\""])
-                return
+            let authorizationHeaderComponents = authorizationHeader.components(separatedBy: " ")
+            guard authorizationHeaderComponents.count >= 2,
+                authorizationHeaderComponents[0] == "Basic",
+                let decodedData = Data(base64Encoded: authorizationHeaderComponents[1], options: options),
+                let userAuthorization = String(data: decodedData, encoding: .utf8) else {
+                    onPass(.unauthorized, ["WWW-Authenticate" : "Basic realm=\"" + self.realm + "\""])
+                    return
             }
             
             authorization = userAuthorization as String

--- a/Tests/CredentialsHTTPTests/TestBasic.swift
+++ b/Tests/CredentialsHTTPTests/TestBasic.swift
@@ -83,6 +83,15 @@ class TestBasic : XCTestCase {
                 expectation.fulfill()
                 }, headers: ["Authorization" : "Basic QWxhZGRpbjpPcGVuU2VzYW1l"])
         }
+        
+        performServerTest(router: router) { expectation in
+            self.performRequest(method: "get", path:"/private/apiv2/data", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response!.headers["WWW-Authenticate"]!.first!, "Basic realm=\"test\"")
+                expectation.fulfill()
+            }, headers: ["Authorization" : "Basic"])
+        }
     }
     
     func testBasic() {


### PR DESCRIPTION
Fix IBM-Swift/Kitura-CredentialsHTTP#33: check that the Authorization header contains at least two components before accessing them