### PR TITLE
Fix URL comparison in CredentialsHTTP Digest

### DIFF
--- a/Sources/CredentialsHTTP/CredentialsHTTPDigest.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPDigest.swift
@@ -18,6 +18,7 @@ import Kitura
 import KituraNet
 import Credentials
 import Cryptor
+import LoggerAPI
 
 import Foundation
 
@@ -177,6 +178,7 @@ public class CredentialsHTTPDigest : CredentialsPluginProtocol {
                 splitRegex = try RegularExpressionType(pattern: ",(?=(?:[^\"]|\"[^\"]*\")*$)", options: [])
             }
             catch {
+                Log.error("Failed to create regular expressions used to parse Digest Authorization header")
                 exit(1)
             }
         }
@@ -229,9 +231,6 @@ public class CredentialsHTTPDigest : CredentialsPluginProtocol {
         var result = url.path
         if let query = url.query {
             result = result + "?" + query
-        }
-        if let fragment = url.fragment {
-            result = result + "#" + fragment
         }
         return result
     }

--- a/Sources/CredentialsHTTP/CredentialsHTTPDigest.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPDigest.swift
@@ -52,6 +52,8 @@ public class CredentialsHTTPDigest : CredentialsPluginProtocol {
     
     private let algorithm = "MD5"
     
+    private static let regularExpressions = RegularExpressions()
+    
     /// Initialize a `CredentialsHTTPDigest` instance.
     ///
     /// - Parameter userProfileLoader: The callback for loading the user profile.
@@ -90,7 +92,8 @@ public class CredentialsHTTPDigest : CredentialsPluginProtocol {
         guard let credentials = CredentialsHTTPDigest.parse(params: String(authorizationHeader.characters.dropFirst(7))), credentials.count > 0,
             let userid = credentials["username"],
             let credentialsRealm = credentials["realm"], credentialsRealm == realm,
-            let credentialsURI = credentials["uri"], credentialsURI == request.urlURL.path,
+            let credentialsURI = credentials["uri"],
+            credentialsURI == CredentialsHTTPDigest.reassembleURI(request.urlURL),
             let credentialsNonce = credentials["nonce"],
             let credentialsCNonce = credentials["cnonce"],
             let credentialsNC = credentials["nc"],
@@ -164,58 +167,71 @@ public class CredentialsHTTPDigest : CredentialsPluginProtocol {
         typealias RegularExpressionType = NSRegularExpression
     #endif
     
+    private struct RegularExpressions {
+        let parseRegex: RegularExpressionType
+        let splitRegex: RegularExpressionType
+        
+        init() {
+            do {
+                parseRegex = try RegularExpressionType(pattern: "(\\w+)=[\"]?([^\"]+)[\"]?$", options: [])
+                splitRegex = try RegularExpressionType(pattern: ",(?=(?:[^\"]|\"[^\"]*\")*$)", options: [])
+            }
+            catch {
+                exit(1)
+            }
+        }
+    }
+    
     private static func parse (params: String) -> [String:String]? {
-        guard let tokens = split(originalString: params, pattern: ",(?=(?:[^\"]|\"[^\"]*\")*$)") else {
+        guard let tokens = split(originalString: params) else {
             return nil
         }
         
         var result = [String:String]()
         for token in tokens {
             let nsString = NSString(string: token)
-            do {
-                let regex = try RegularExpressionType(pattern: "(\\w+)=[\"]?([^\"]+)[\"]?$", options: [])
-                
-                let matches = regex.matches(in: token, options: [], range: NSMakeRange(0, nsString.length))
-                if matches.count == 1 {
-                    #if os(Linux)
-                        let matchOne = matches[0].range(at: 1)
-                        let matchTwo = matches[0].range(at: 2)
-                    #else
-                        let matchOne = matches[0].rangeAt(1)
-                        let matchTwo = matches[0].rangeAt(2)
-                    #endif
-                    if matchOne.location != NSNotFound && matchTwo.location != NSNotFound {
-                        result[nsString.substring(with: matchOne)] = nsString.substring(with: matchTwo)
-                    }
+            let matches = regularExpressions.parseRegex.matches(in: token, options: [], range: NSMakeRange(0, nsString.length))
+            if matches.count == 1 {
+                #if os(Linux)
+                    let matchOne = matches[0].range(at: 1)
+                    let matchTwo = matches[0].range(at: 2)
+                #else
+                    let matchOne = matches[0].rangeAt(1)
+                    let matchTwo = matches[0].rangeAt(2)
+                #endif
+                if matchOne.location != NSNotFound && matchTwo.location != NSNotFound {
+                    result[nsString.substring(with: matchOne)] = nsString.substring(with: matchTwo)
                 }
-            } catch  {
-                return nil
             }
         }
         return result
     }
     
-    
-    private static func split(originalString: String, pattern: String) -> [String]? {
+    private static func split(originalString: String) -> [String]? {
         var result = [String]()
-        do {
-            let regex = try RegularExpressionType(pattern: pattern, options: [])
-            
-            let nsString = NSString(string: originalString)
-            var start = 0
-            while true {
-                let results = regex.rangeOfFirstMatch(in: originalString, options: [], range: NSMakeRange(start, nsString.length - start))
-                if results.location == NSNotFound {
-                    result.append(nsString.substring(from: start))
-                    break
-                }
-                else {
-                    result.append(nsString.substring(with: NSMakeRange(start, results.location - start)))
-                    start = results.length + results.location
-                }
+        let nsString = NSString(string: originalString)
+        var start = 0
+        while true {
+            let results = regularExpressions.splitRegex.rangeOfFirstMatch(in: originalString, options: [], range: NSMakeRange(start, nsString.length - start))
+            if results.location == NSNotFound {
+                result.append(nsString.substring(from: start))
+                break
             }
-        } catch {
-            return nil
+            else {
+                result.append(nsString.substring(with: NSMakeRange(start, results.location - start)))
+                start = results.length + results.location
+            }
+        }
+        return result
+    }
+    
+    private static func reassembleURI(_ url: URL) -> String {
+        var result = url.path
+        if let query = url.query {
+            result = result + "?" + query
+        }
+        if let fragment = url.fragment {
+            result = result + "#" + fragment
         }
         return result
     }

--- a/Tests/CredentialsHTTPTests/TestDigest.swift
+++ b/Tests/CredentialsHTTPTests/TestDigest.swift
@@ -70,7 +70,7 @@ class TestDigest : XCTestCase {
     
     func testDigest() {
         performServerTest(router: router) { expectation in
-            self.performRequest(method: "get", path:"/private/api/data", callback: {response in
+            self.performRequest(method: "get", path:"/private/api/data?name=kitura", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
                 do {
@@ -82,7 +82,7 @@ class TestDigest : XCTestCase {
                 }
 
                 expectation.fulfill()
-                }, headers: ["Authorization" : "Digest username=\"Mary\", realm=\"test\",nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\",    uri=\"/private/api/data\",  qop=auth,                       nc=00000001, cnonce=\"0a4f113b\", response=\"59e3cce95566f4dd0262d812a12b9bb6\",  opaque=\"0a0b0c0d\""])
+                }, headers: ["Authorization" : "Digest username=\"Mary\", realm=\"test\",nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\",    uri=\"/private/api/data?name=kitura\",  qop=auth,                       nc=00000001, cnonce=\"0a4f113b\", response=\"c96305e606f035fceac5f5ff10b0951a\",  opaque=\"0a0b0c0d\""])
         }
     }
     


### PR DESCRIPTION
IBM-Swift/Kitura#1002

URL comparison of Digest Authorization header ignores query and fragment, this PR reassembles the URL with query and fragment for correct comparison.

It also makes regular expressions used for the header parsing static. 
