### PR TITLE
update credentials package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],    
     dependencies: [
-         .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", .upToNextMinor(from: "2.0.0")),
+         .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Update Kitura-Credentials.git dependency to take up to next major so that it works with Kitura-Credentials 2.1.0 (and hence kitura 2.2.0) and gives us more flexibility in our dependencies.