### PR TITLE
This is a fix for colons in the password of a HTTP Basic Authentication.

### DIFF
--- a/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
@@ -107,14 +107,14 @@ public class CredentialsHTTPBasic : CredentialsPluginProtocol {
             authorization = userAuthorization as String
         }
         
-        let credentials = authorization.components(separatedBy: ":")
-        guard credentials.count >= 2 else {
+        let credentials = authorization.split(separator: ":", maxSplits: 1)
+        guard credentials.count == 2 else {
             onFailure(.badRequest, nil)
             return
         }
         
-        let userid = credentials[0]
-        let password = credentials[1...].joined(separator: ":")
+        let userid = String(credentials[0])
+        let password = String(credentials[1])
         
         if let userProfileLoader = self.userProfileLoader {
             userProfileLoader(userid) { userProfile, storedPassword in

--- a/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
@@ -114,7 +114,7 @@ public class CredentialsHTTPBasic : CredentialsPluginProtocol {
         }
         
         let userid = credentials[0]
-        let password = credentials[1]
+        let password = credentials[1...].joined(separator: ":")
         
         if let userProfileLoader = self.userProfileLoader {
             userProfileLoader(userid) { userProfile, storedPassword in


### PR DESCRIPTION
The existing code was taking the first component of the colon-separated array as the user name,
and the second as the password. In fact, all components after the first must be treated as belonging
to the password, and joined together with a colon separator.

Fix for https://github.com/IBM-Swift/Kitura-CredentialsHTTP/issues/54