### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
+++ b/Sources/CredentialsHTTP/CredentialsHTTPBasic.swift
@@ -50,7 +50,8 @@ public class CredentialsHTTPBasic : CredentialsPluginProtocol {
     ///
     /// - Parameter userProfileLoader: The callback for loading the user profile.
     /// - Parameter realm: The realm attribute.
-    @available(*, deprecated: 2.0, message: "userProfileLoader has been deprecated from Basic Authentication because of security improvements. Please use verifyPassword.")  public init (userProfileLoader: @escaping UserProfileLoader, realm: String?=nil) {
+    @available(*, deprecated, message: "userProfileLoader has been deprecated from Basic Authentication because of security improvements. Please use verifyPassword.")
+    public init (userProfileLoader: @escaping UserProfileLoader, realm: String?=nil) {
         self.userProfileLoader = userProfileLoader
         self.realm = realm ?? "Users"
     }

--- a/Tests/CredentialsHTTPTests/TestBasic.swift
+++ b/Tests/CredentialsHTTPTests/TestBasic.swift
@@ -48,18 +48,22 @@ class TestBasic : XCTestCase {
     func testNoCredentials() {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", host: self.host, path: "/private/apiv1/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response?.statusCode)")
-                XCTAssertEqual(response?.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response.statusCode)")
+                XCTAssertEqual(response.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
                 expectation.fulfill()
             })
         }
 
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", host: self.host, path: "/private/apiv2/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response?.statusCode)")
-                XCTAssertEqual(response?.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response.statusCode)")
+                XCTAssertEqual(response.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
                 expectation.fulfill()
             })
         }
@@ -68,27 +72,33 @@ class TestBasic : XCTestCase {
     func testBadCredentials() {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/apiv1/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response?.statusCode)")
-                XCTAssertEqual(response?.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response.statusCode)")
+                XCTAssertEqual(response.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
                 expectation.fulfill()
                 }, headers: ["Authorization" : "Basic QWxhZGRpbjpPcGVuU2VzYW1l"])
         }
         
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/apiv2/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response?.statusCode)")
-                XCTAssertEqual(response?.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response.statusCode)")
+                XCTAssertEqual(response.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
                 expectation.fulfill()
                 }, headers: ["Authorization" : "Basic QWxhZGRpbjpPcGVuU2VzYW1l"])
         }
         
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/apiv2/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response?.statusCode)")
-                XCTAssertEqual(response?.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response.statusCode)")
+                XCTAssertEqual(response.headers["WWW-Authenticate"]?.first, "Basic realm=\"test\"")
                 expectation.fulfill()
             }, headers: ["Authorization" : "Basic"])
         }
@@ -97,10 +107,12 @@ class TestBasic : XCTestCase {
     func testBasic() {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/apiv1/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response.statusCode)")
                 do {
-                    let body = try response?.readString()
+                    let body = try response.readString()
                     XCTAssertEqual(body,"<!DOCTYPE html><html><body><b>Mary is logged in with HTTPBasic</b></body></html>\n\n")
                 }
                 catch{
@@ -112,10 +124,12 @@ class TestBasic : XCTestCase {
         
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/apiv2/data", callback: {response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                guard let response = response else {
+                    return XCTFail("ERROR!!! ClientRequest response object was nil")
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response.statusCode)")
                 do {
-                    let body = try response?.readString()
+                    let body = try response.readString()
                     XCTAssertEqual(body,"<!DOCTYPE html><html><body><b>Mary is logged in with HTTPBasic</b></body></html>\n\n")
                 }
                 catch{


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Also fixes an invalid Swift version number in an `@available` annotation on the `CredentialsHTTPBasic.init(userProfileLoader:)` initializer.  The intention was to mark this as deprecated from v2 of this repo, but that's not what the deprecation syntax means - it is specifically the _swift_ version that the deprecation applies to.  2.0 is not a valid Swift version in this context and Swift 5 now warns us about that.